### PR TITLE
Fix es6 incompatible db scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,14 @@
+# App env
+PORT=
+
+# DB env
 DB_USER='enter_your_db_username'
 DB_PASSWORD='enter_your_db_password'
 DB_NAME='enter_your_db_name'
+DB_HOST='enter_your_db_host'
+
+# Test DB env
+DB_TEST_HOST='enter_your_db_test_host'
 DB_TEST_USERNAME='enter_your_db_username'
 DB_TEST_PASSWORD='enter_your_db_password'
 DB_TEST_NAME='enter_your_db_name'

--- a/.sequelizerc
+++ b/.sequelizerc
@@ -1,8 +1,9 @@
-import path from 'path';
+require ('@babel/register')
+const path = require('path')
 
-export default {
+module.exports = {
   'config': path.resolve('src/db/config', 'config.js'),
   'models-path': path.resolve('src/db', 'models'),
   'seeders-path': path.resolve('src/db', 'seeders'),
   'migrations-path': path.resolve('src/db', 'migrations')
-};
+};  

--- a/src/db/config/config.js
+++ b/src/db/config/config.js
@@ -1,8 +1,6 @@
-import dotenv from "dotenv";
+require("dotenv").config();
 
-dotenv.config();
-
-export default {
+module.exports = {
   development: {
     username: process.env.DB_USER,
     password: process.env.DB_PASSWORD,

--- a/src/db/config/config.js
+++ b/src/db/config/config.js
@@ -7,7 +7,7 @@ export default {
     username: process.env.DB_USER,
     password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME,
-    host: "127.0.0.1",
+    host: process.env.DB_HOST || "127.0.0.1",
     port: 5432,
     dialect: "postgres",
     dialectOptions: {
@@ -18,7 +18,7 @@ export default {
     username: process.env.DB_TEST_USERNAME,
     password: process.env.DB_TEST_PASSWORD,
     database: process.env.DB_TEST_NAME,
-    host: "127.0.0.1",
+    host: process.env.DB_TEST_HOST || "127.0.0.1",
     port: 5432,
     dialect: "postgres",
     dialectOptions: {


### PR DESCRIPTION
## What does this PR do

It adds a fix to incompatible db scripts failing. 

## Producing the issue 

- Checkout to develop branch
- Run any db script eg: `npm run db:g:migration --name test`
- The command should fail with the error `import path from 'path';`

## How to manually test the fix

- Checkout to branch `fix-es6-incompatible-db-scripts`
- Run the same db script `npm run db:g:migration --name test`
- The script should run without any error

## Relevant Trello story 

N/A

## Screenshot

Producing error 
<img width="1365" alt="image" src="https://user-images.githubusercontent.com/54368821/226198369-ae6429d7-534d-4e21-b592-5460a6bc03ba.png">

Testing the fix
<img width="1365" alt="image" src="https://user-images.githubusercontent.com/54368821/226198441-d0c98a93-5582-4f70-91f5-a5a08486d5e4.png">

